### PR TITLE
Async function without callback is deprecated in Node v7

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,11 @@ export default function(files, schemaPath, subdir = '__relay__') {
                     }
 
                     const outputFileContents = generate(flowtypes, path.basename(filename));
-                    fs.writeFile(outputFilename, outputFileContents, {encoding: 'utf8'});
+                    fs.writeFile(outputFilename, outputFileContents, {encoding: 'utf8'}, (err) => {
+                        if (err) {
+                            process.stderr.write(JSON.stringify(err));
+                        }
+                    });
                 }
             }
         });


### PR DESCRIPTION
Fixes the spam of deprecation warnings you get in node v7:
```
(node:19388) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
(node:19388) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
(node:19388) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
(node:19388) DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```

Not sure whether to just output error or throw it, however. Your call.