### PR TITLE
Fix formatting errors for Prettier

### DIFF
--- a/src/__tests__/testParse.js
+++ b/src/__tests__/testParse.js
@@ -114,6 +114,33 @@ Relay.QL\`query {
         });
     });
 
+    fit('should handle long comments and weird interpolation', () => {
+        expect(parse(`
+            Relay.QL\`
+                fragment on User {
+					\${commentUserFragment}
+					todos(first: 5) {
+                        title
+                    }
+					\${Something.getFragment('whatever')} # something really long like so long that it might wrap around or something like that you know like really long
+                }
+            \`
+        `, schema)).toEqual({
+            UserFragmentType: {type: 'fragment', flowtypes: [{
+				todos: {
+					type: 'list', ofType: {
+						type: 'object', 
+						object: {
+					    	title: {type: 'string', nonNull: true}
+						},
+						nonNull: true
+					}, 
+					nonNull: true
+				}
+			}]}
+        });
+    });
+
     it('should handle empty lists of items', () => {
         expect(parse(`
             Relay.QL\`

--- a/src/__tests__/testParse.js
+++ b/src/__tests__/testParse.js
@@ -114,7 +114,7 @@ Relay.QL\`query {
         });
     });
 
-    fit('should handle long comments and weird interpolation', () => {
+    it('should handle long comments and weird interpolation', () => {
         expect(parse(`
             Relay.QL\`
                 fragment on User {

--- a/src/__tests__/testParse.js
+++ b/src/__tests__/testParse.js
@@ -99,6 +99,21 @@ Relay.QL\`query {
         });
     });
 
+
+    it('should handle multiline fragment interpolation', () => {
+        expect(parse(`
+            Relay.QL\`
+                fragment on User {
+                    \${Something.getFragment(
+						'whatever'
+					)}
+                }
+            \`
+        `, schema)).toEqual({
+            UserFragmentType: {type: 'fragment', flowtypes: [{}]}
+        });
+    });
+
     it('should handle empty lists of items', () => {
         expect(parse(`
             Relay.QL\`

--- a/src/parse.js
+++ b/src/parse.js
@@ -17,11 +17,12 @@ export default function(contents, schema) {
         const originalQueryString = match[1];
         // Fix Relay's non-standard GraphQL
         let queryString = originalQueryString.replace('fragment on', 'fragment F1 on');
+		// Remove newlines that may come from formatting and would break the regex below
+        queryString = queryString.replace(/\n/g, ' ');
         // Removing fragments could make an object empty so put a placeholder in there - __typename is something we know
         // will always be available
         queryString = queryString.replace(/\$\{.*?\.getFragment\(.*?\)}/g, `${PLACEHOLDER_FIELD_NAME}: __typename`);
         queryString = queryString.replace(/\$\{[a-zA-Z0-9_]+}/g, `${PLACEHOLDER_FIELD_NAME}: __typename`);
-
         const parsed = parse(new Source(queryString));
         const definition = parsed.definitions[0];
         switch (definition.kind) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -17,12 +17,14 @@ export default function(contents, schema) {
         const originalQueryString = match[1];
         // Fix Relay's non-standard GraphQL
         let queryString = originalQueryString.replace('fragment on', 'fragment F1 on');
+		// Remove comments
+        queryString = queryString.replace(/#.*/g, ' ');
 		// Remove newlines that may come from formatting and would break the regex below
         queryString = queryString.replace(/\n/g, ' ');
+        queryString = queryString.replace(/\$\{[a-zA-Z0-9_]+}/g, `${PLACEHOLDER_FIELD_NAME}: __typename`);
         // Removing fragments could make an object empty so put a placeholder in there - __typename is something we know
         // will always be available
         queryString = queryString.replace(/\$\{.*?\.getFragment\(.*?\)}/g, `${PLACEHOLDER_FIELD_NAME}: __typename`);
-        queryString = queryString.replace(/\$\{[a-zA-Z0-9_]+}/g, `${PLACEHOLDER_FIELD_NAME}: __typename`);
         const parsed = parse(new Source(queryString));
         const definition = parsed.definitions[0];
         switch (definition.kind) {


### PR DESCRIPTION
Prettier likes to maintain line lengths, this is sometimes impossible in template strings, however it (cleverly?) breaks them on interpolation. This meant that this regex was failing:
```
queryString.replace(/\$\{.*?\.getFragment\(.*?\)}/g, 
```
since the getFragment call was split over multiple lines to fit in the arguments. See test for details.